### PR TITLE
Gem update + README tweak

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,38 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.24)
-      unf (>= 0.0.5, < 1.0.0)
+    base64 (0.2.0)
+    domain_name (0.6.20240107)
     erubis (2.7.0)
-    excon (0.45.3)
-    heroics (0.0.14)
-      erubis (~> 2.7.0)
+    excon (0.110.0)
+    heroics (0.1.3)
+      base64
+      erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-      netrc
-    http-cookie (1.0.2)
+      webrick
+    http-accept (1.7.0)
+    http-cookie (1.0.6)
       domain_name (~> 0.5)
-    mime-types (2.5)
-    moneta (0.8.0)
-    multi_json (1.11.0)
-    netrc (0.10.3)
-    pg (0.18.1)
-    platform-api (0.2.0)
-      heroics (~> 0.0.10)
-    rest-client (1.8.0)
+    mime-types (3.5.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2024.0604)
+    moneta (1.0.0)
+    multi_json (1.15.0)
+    netrc (0.11.0)
+    pg (1.5.6)
+    platform-api (3.7.0)
+      heroics (~> 0.1.1)
+      moneta (~> 1.0.0)
+      rate_throttle_client (~> 0.1.0)
+    rate_throttle_client (0.1.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.1)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -35,3 +41,6 @@ DEPENDENCIES
   pg
   platform-api
   rest-client
+
+BUNDLED WITH
+   2.3.23

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ heroku config:set APP=$APP-backups \
   FORK_FROM_APP=$APP \
   HEROKU_API_KEY=$(heroku auth:token) \
   --app $APP-backups
+heroku git:remote -a $APP-backups
 git push heroku master
 ```
 


### PR DESCRIPTION
It's been a long time, and pg 0.18.1 no longer runs on Heroku.

This updates all gems for 2024, and updates the README to mention adding the Heroku remote, without which the suggested commands fail.